### PR TITLE
Playbook push registry

### DIFF
--- a/ansible/playbooks/buildImage.yml
+++ b/ansible/playbooks/buildImage.yml
@@ -13,6 +13,20 @@
         owner: root
         group: root
         mode: '0755'
+    - name: copy Dockerfile
+      copy:
+        src: ../../Dockerfile
+        dest: /root/demo-dockerfile/Dockerfile
+        owner: root
+        group: root
+        mode: '0644'
+    - name: copy src
+      copy:
+        src: ../../src
+        dest: /root/demo-dockerfile/src
+        owner: root
+        group: root
+        mode: '0644'
     - name: build container image
       docker_image:
         name: localhost:5000/static

--- a/ansible/playbooks/buildImage.yml
+++ b/ansible/playbooks/buildImage.yml
@@ -13,20 +13,6 @@
         owner: root
         group: root
         mode: '0755'
-    - name: copy Dockerfile
-      copy:
-        src: ../../Dockerfile
-        dest: /root/demo-dockerfile/Dockerfile
-        owner: root
-        group: root
-        mode: '0644'
-    - name: copy src
-      copy:
-        src: ../../src
-        dest: /root/demo-dockerfile/src
-        owner: root
-        group: root
-        mode: '0644'
     - name: build container image
       docker_image:
         name: static

--- a/ansible/playbooks/buildImage.yml
+++ b/ansible/playbooks/buildImage.yml
@@ -15,12 +15,10 @@
         mode: '0755'
     - name: build container image
       docker_image:
-        name: static
+        name: localhost:5000/static
         build:
           path: /root/demo-dockerfile
         source: build
         state: present
         push: yes
-        tags:
-          - "latest"
-        repository: "localhost:5000"
+        tags: latest

--- a/ansible/playbooks/buildImage.yml
+++ b/ansible/playbooks/buildImage.yml
@@ -35,4 +35,6 @@
         source: build
         state: present
         push: yes
-        repository: "localhost:5000:latest"
+        tags:
+          - "latest"
+        repository: "localhost:5000"

--- a/ansible/playbooks/buildImage.yml
+++ b/ansible/playbooks/buildImage.yml
@@ -34,3 +34,5 @@
           path: /root/demo-dockerfile
         source: build
         state: present
+        push: yes
+        repository: "localhost:5000:latest"


### PR DESCRIPTION
Push our newly created image straight to our local image repository

It's necessary right now because the trivy user won't have access to the image otherwise (needs some group management)